### PR TITLE
Change returned image files to use `require`

### DIFF
--- a/cc.go
+++ b/cc.go
@@ -113,10 +113,11 @@ var cc = template.Must(template.New("cc").Funcs(template.FuncMap{
 -- /___/  by 1lann - github.com/tmpim/juroku
 --
 -- Usage:
--- os.loadAPI("image")
+-- local image = require("image")
 -- image.draw(term) or image.draw(monitor)
+local image = {}
 
-function draw(t)
+function image.draw(t)
 	local x, y = t.getCursorPos()
 
 	{{range $index, $color := .Palette -}}
@@ -129,7 +130,7 @@ function draw(t)
 	{{end}}
 end
 
-function getColors()
+function image.getColors()
 	local colors = {}
 	{{range $index, $color := .Palette -}}
 	table.insert(colors, 2^{{$index}}, 0x{{colorToHex $color}})
@@ -138,7 +139,9 @@ function getColors()
 	return colors
 end
 
-function getSize()
+function image.getSize()
 	return {{.Width}}, {{.Height}}
 end
+
+return image
 `))


### PR DESCRIPTION
This changes the generated `.lua` files to use `require` instead of the deprecated `os.loadAPI`.